### PR TITLE
Total heating in GJ option for driver_vario451.h

### DIFF
--- a/driver_vario451.h
+++ b/driver_vario451.h
@@ -17,6 +17,7 @@ struct Vario451: Driver
     std::map<std::string, float> ret_val{};
 
     add_to_map(ret_val, "total_heating_kwh", this->total_heating_kwh(telegram));
+    add_to_map(ret_val, "total_heating_gj", this->total_heating_gj(telegram));
 
     if (ret_val.size() > 0) {
       return ret_val;
@@ -28,15 +29,22 @@ struct Vario451: Driver
 
 private:
   esphome::optional<float> total_heating_kwh(std::vector<unsigned char> &telegram) {
-    esphome::optional<float> ret_val{};
+    // in kWh
+      float total_heating_in_kwh = get_total_heating_in_gj(telegram) * 277.777;
+      return esphome::make_optional(total_heating_in_kwh);
+  }
+
+  esphome::optional<float> total_heating_gj(std::vector<unsigned char> &telegram) {
+    // in GJ
+    return esphome::make_optional(get_total_heating_in_gj(telegram));
+  }
+
+  float get_total_heating_in_gj(const std::vector<unsigned char> &telegram) const {
     float usage = 0;
     size_t i = 11;
 
     usage = ((((uint32_t)telegram[i+4] << 8) + (uint32_t)telegram[i+3]) / 1000.0) + 
             ((((uint32_t)telegram[i+8] << 8) + (uint32_t)telegram[i+7]) / 1000.0);
-    // in kWh
-    ret_val = usage * 277.777 ;
-
-    return ret_val;
+    return usage;
   };
 };


### PR DESCRIPTION
Hi, I would like to add an option to send the total energy consumtion in Gigajoule unit for Vario 4.5.1 meter.

Once accepted I will submit PR to [esphome-components](https://github.com/SzczepanLeon/esphome-components).