### PR TITLE
Amiplus-patch for tarrifs T1, T2, T3, T4

### DIFF
--- a/driver_amiplus.h
+++ b/driver_amiplus.h
@@ -17,9 +17,9 @@ struct Amiplus: Driver
     std::map<std::string, double> ret_val{};
 
     add_to_map(ret_val, "total_energy_consumption_kwh", this->get_total_energy_consumption_kwh(telegram));
-    add_to_map(ret_val, "total_energy_consumption_t1_kwh", this->get_total_energy_consumption_t1_kwh(telegram));
-    add_to_map(ret_val, "total_energy_consumption_t2_kwh", this->get_total_energy_consumption_t2_kwh(telegram));
-    add_to_map(ret_val, "total_energy_consumption_t3_kwh", this->get_total_energy_consumption_t3_kwh(telegram));
+    add_to_map(ret_val, "total_energy_consumption_t1_kwh", this->get_total_energy_consumption_t_kwh(1, telegram));
+    add_to_map(ret_val, "total_energy_consumption_t2_kwh", this->get_total_energy_consumption_t_kwh(2, telegram));
+    add_to_map(ret_val, "total_energy_consumption_t3_kwh", this->get_total_energy_consumption_t_kwh(3, telegram));
     add_to_map(ret_val, "current_power_consumption_kw", this->get_current_power_consumption_kw(telegram));
     add_to_map(ret_val, "total_energy_production_kwh", this->get_total_energy_production_kwh(telegram));
     add_to_map(ret_val, "current_power_production_kw", this->get_current_power_production_kw(telegram));
@@ -58,64 +58,26 @@ private:
     return ret_val;
   };
 
+  esphome::optional<double> get_total_energy_consumption_t_kwh(uint8_t tarrif, std::vector<unsigned char> &telegram) {
+    esphome::optional<double> ret_val{};
+    uint32_t usage = 0;
+    size_t i = 11;
+    uint32_t total_register = 0x8E0003 | ((tarrif*10) << 8);
+    while (i < telegram.size()) {
+      uint32_t c = (((uint32_t)telegram[i+0] << 16) | ((uint32_t)telegram[i+1] << 8 ) | ((uint32_t)telegram[i+2]) );
+      if (c == total_register) {
+        i += 4;
+        usage = bcd_2_int(telegram, i, 6);
+        ret_val = usage / 1000.0;
+        ESP_LOGVV(TAG, "Found register '%X' with '%d'->'%f'", total_register, usage, ret_val.value());
+        break;
+      }
+      i++;
+    }
+    return ret_val;
+  };  
+
   esphome::optional<double> get_total_energy_consumption_kwh(std::vector<unsigned char> &telegram) {
-    esphome::optional<double> ret_val{};
-    uint32_t usage = 0;
-    size_t i = 11;
-    uint32_t total_register = 0x0E03;
-    while (i < telegram.size()) {
-      uint32_t c = (((uint32_t)telegram[i+0] << 8) | ((uint32_t)telegram[i+1]));
-      if (c == total_register) {
-        i += 2;
-        usage = bcd_2_int(telegram, i, 6);
-        ret_val = usage / 1000.0;
-        ESP_LOGVV(TAG, "Found register '0E03' with '%d'->'%f'", usage, ret_val.value());
-        break;
-      }
-      i++;
-    }
-    return ret_val;
-  };
-
-  esphome::optional<double> get_total_energy_consumption_t1_kwh(std::vector<unsigned char> &telegram) {
-    esphome::optional<double> ret_val{};
-    uint32_t usage = 0;
-    size_t i = 11;
-    uint32_t total_register = 0x0E03;
-    while (i < telegram.size()) {
-      uint32_t c = (((uint32_t)telegram[i+0] << 8) | ((uint32_t)telegram[i+1]));
-      if (c == total_register) {
-        i += 2;
-        usage = bcd_2_int(telegram, i, 6);
-        ret_val = usage / 1000.0;
-        ESP_LOGVV(TAG, "Found register '0E03' with '%d'->'%f'", usage, ret_val.value());
-        break;
-      }
-      i++;
-    }
-    return ret_val;
-  };
-
-  esphome::optional<double> get_total_energy_consumption_t2_kwh(std::vector<unsigned char> &telegram) {
-    esphome::optional<double> ret_val{};
-    uint32_t usage = 0;
-    size_t i = 11;
-    uint32_t total_register = 0x0E03;
-    while (i < telegram.size()) {
-      uint32_t c = (((uint32_t)telegram[i+0] << 8) | ((uint32_t)telegram[i+1]));
-      if (c == total_register) {
-        i += 2;
-        usage = bcd_2_int(telegram, i, 6);
-        ret_val = usage / 1000.0;
-        ESP_LOGVV(TAG, "Found register '0E03' with '%d'->'%f'", usage, ret_val.value());
-        break;
-      }
-      i++;
-    }
-    return ret_val;
-  };
-
-  esphome::optional<double> get_total_energy_consumption_t3_kwh(std::vector<unsigned char> &telegram) {
     esphome::optional<double> ret_val{};
     uint32_t usage = 0;
     size_t i = 11;

--- a/driver_amiplus.h
+++ b/driver_amiplus.h
@@ -20,8 +20,13 @@ struct Amiplus: Driver
     add_to_map(ret_val, "total_energy_consumption_t1_kwh", this->get_total_energy_consumption_t_kwh(1, telegram));
     add_to_map(ret_val, "total_energy_consumption_t2_kwh", this->get_total_energy_consumption_t_kwh(2, telegram));
     add_to_map(ret_val, "total_energy_consumption_t3_kwh", this->get_total_energy_consumption_t_kwh(3, telegram));
+    add_to_map(ret_val, "total_energy_consumption_t4_kwh", this->get_total_energy_consumption_t_kwh(4, telegram));
     add_to_map(ret_val, "current_power_consumption_kw", this->get_current_power_consumption_kw(telegram));
     add_to_map(ret_val, "total_energy_production_kwh", this->get_total_energy_production_kwh(telegram));
+    add_to_map(ret_val, "total_energy_production_t1_kwh", this->get_total_energy_production_t_kwh(1, telegram));
+    add_to_map(ret_val, "total_energy_production_t2_kwh", this->get_total_energy_production_t_kwh(2, telegram));
+    add_to_map(ret_val, "total_energy_production_t3_kwh", this->get_total_energy_production_t_kwh(3, telegram));
+    add_to_map(ret_val, "total_energy_production_t4_kwh", this->get_total_energy_production_t_kwh(4, telegram));
     add_to_map(ret_val, "current_power_production_kw", this->get_current_power_production_kw(telegram));
     add_to_map(ret_val, "voltage_at_phase_1_v", this->get_voltage_at_phase_v(1, telegram));
     add_to_map(ret_val, "voltage_at_phase_2_v", this->get_voltage_at_phase_v(2, telegram));
@@ -62,11 +67,34 @@ private:
     esphome::optional<double> ret_val{};
     uint32_t usage = 0;
     size_t i = 11;
-    uint32_t total_register = 0x8E0003 | ((tarrif*16) << 8);
+    uint32_t total_register = tarrif < 4 ? 0x8E0003 | ((tarrif*16) << 8) : 0x8E801003;
     while (i < telegram.size()) {
-      uint32_t c = (((uint32_t)telegram[i+0] << 16) | ((uint32_t)telegram[i+1] << 8 ) | ((uint32_t)telegram[i+2]) );
+      uint32_t c = tarrif < 4 ? 
+                (((uint32_t)telegram[i+0] << 16) | ((uint32_t)telegram[i+1] << 8 ) | ((uint32_t)telegram[i+2]) )
+                : (((uint32_t)telegram[i+0] << 24) | ((uint32_t)telegram[i+1] << 16 ) | ((uint32_t)telegram[i+2] << 8) | ((uint32_t)telegram[i+3]) );
       if (c == total_register) {
-        i += 3;
+        i += tarrif < 4 ? 3 : 4;
+        usage = bcd_2_int(telegram, i, 6);
+        ret_val = usage / 1000.0;
+        ESP_LOGVV(TAG, "Found register '%X' with '%d'->'%f'", total_register, usage, ret_val.value());
+        break;
+      }
+      i++;
+    }
+    return ret_val;
+  };
+
+   esphome::optional<double> get_total_energy_production_t_kwh(uint8_t tarrif, std::vector<unsigned char> &telegram) {
+    esphome::optional<double> ret_val{};
+    uint32_t usage = 0;
+    size_t i = 11;
+    uint64_t total_register = tarrif < 4 ? 0x8E00833C | ((tarrif*16) << 24) : 0x8E8010833C;
+    while (i < telegram.size()) {
+      uint64_t c = tarrif < 4 ? 
+                  (((uint32_t)telegram[i+0] << 24) | ((uint32_t)telegram[i+1] << 16 ) | ((uint32_t)telegram[i+2] << 8) | ((uint32_t)telegram[i+3]) )
+                  : (((uint64_t)telegram[i+0] << 32) | ((uint32_t)telegram[i+1] << 24 ) | ((uint32_t)telegram[i+2] << 16) | ((uint32_t)telegram[i+3] << 8) | ((uint32_t)telegram[i+4]));
+      if (c == total_register) {
+        i += tarrif < 4 ? 4 : 5;
         usage = bcd_2_int(telegram, i, 6);
         ret_val = usage / 1000.0;
         ESP_LOGVV(TAG, "Found register '%X' with '%d'->'%f'", total_register, usage, ret_val.value());
@@ -114,6 +142,7 @@ private:
     }
     return ret_val;
   };
+
 
   esphome::optional<double> get_total_energy_production_kwh(std::vector<unsigned char> &telegram) {
     esphome::optional<double> ret_val{};

--- a/driver_amiplus.h
+++ b/driver_amiplus.h
@@ -17,6 +17,9 @@ struct Amiplus: Driver
     std::map<std::string, double> ret_val{};
 
     add_to_map(ret_val, "total_energy_consumption_kwh", this->get_total_energy_consumption_kwh(telegram));
+    add_to_map(ret_val, "total_energy_consumption_t1_kwh", this->get_total_energy_consumption_t1_kwh(telegram));
+    add_to_map(ret_val, "total_energy_consumption_t2_kwh", this->get_total_energy_consumption_t2_kwh(telegram));
+    add_to_map(ret_val, "total_energy_consumption_t3_kwh", this->get_total_energy_consumption_t3_kwh(telegram));
     add_to_map(ret_val, "current_power_consumption_kw", this->get_current_power_consumption_kw(telegram));
     add_to_map(ret_val, "total_energy_production_kwh", this->get_total_energy_production_kwh(telegram));
     add_to_map(ret_val, "current_power_production_kw", this->get_current_power_production_kw(telegram));
@@ -56,6 +59,63 @@ private:
   };
 
   esphome::optional<double> get_total_energy_consumption_kwh(std::vector<unsigned char> &telegram) {
+    esphome::optional<double> ret_val{};
+    uint32_t usage = 0;
+    size_t i = 11;
+    uint32_t total_register = 0x0E03;
+    while (i < telegram.size()) {
+      uint32_t c = (((uint32_t)telegram[i+0] << 8) | ((uint32_t)telegram[i+1]));
+      if (c == total_register) {
+        i += 2;
+        usage = bcd_2_int(telegram, i, 6);
+        ret_val = usage / 1000.0;
+        ESP_LOGVV(TAG, "Found register '0E03' with '%d'->'%f'", usage, ret_val.value());
+        break;
+      }
+      i++;
+    }
+    return ret_val;
+  };
+
+  esphome::optional<double> get_total_energy_consumption_t1_kwh(std::vector<unsigned char> &telegram) {
+    esphome::optional<double> ret_val{};
+    uint32_t usage = 0;
+    size_t i = 11;
+    uint32_t total_register = 0x0E03;
+    while (i < telegram.size()) {
+      uint32_t c = (((uint32_t)telegram[i+0] << 8) | ((uint32_t)telegram[i+1]));
+      if (c == total_register) {
+        i += 2;
+        usage = bcd_2_int(telegram, i, 6);
+        ret_val = usage / 1000.0;
+        ESP_LOGVV(TAG, "Found register '0E03' with '%d'->'%f'", usage, ret_val.value());
+        break;
+      }
+      i++;
+    }
+    return ret_val;
+  };
+
+  esphome::optional<double> get_total_energy_consumption_t2_kwh(std::vector<unsigned char> &telegram) {
+    esphome::optional<double> ret_val{};
+    uint32_t usage = 0;
+    size_t i = 11;
+    uint32_t total_register = 0x0E03;
+    while (i < telegram.size()) {
+      uint32_t c = (((uint32_t)telegram[i+0] << 8) | ((uint32_t)telegram[i+1]));
+      if (c == total_register) {
+        i += 2;
+        usage = bcd_2_int(telegram, i, 6);
+        ret_val = usage / 1000.0;
+        ESP_LOGVV(TAG, "Found register '0E03' with '%d'->'%f'", usage, ret_val.value());
+        break;
+      }
+      i++;
+    }
+    return ret_val;
+  };
+
+  esphome::optional<double> get_total_energy_consumption_t3_kwh(std::vector<unsigned char> &telegram) {
     esphome::optional<double> ret_val{};
     uint32_t usage = 0;
     size_t i = 11;

--- a/driver_amiplus.h
+++ b/driver_amiplus.h
@@ -88,7 +88,7 @@ private:
     esphome::optional<double> ret_val{};
     uint32_t usage = 0;
     size_t i = 11;
-    uint64_t total_register = tarrif < 4 ? 0x8E00833C | ((tarrif*16) << 24) : 0x8E8010833C;
+    uint64_t total_register = tarrif < 4 ? 0x8E00833C | ((tarrif*16) << 16) : 0x8E8010833C;
     while (i < telegram.size()) {
       uint64_t c = tarrif < 4 ? 
                   (((uint32_t)telegram[i+0] << 24) | ((uint32_t)telegram[i+1] << 16 ) | ((uint32_t)telegram[i+2] << 8) | ((uint32_t)telegram[i+3]) )

--- a/driver_amiplus.h
+++ b/driver_amiplus.h
@@ -62,7 +62,7 @@ private:
     esphome::optional<double> ret_val{};
     uint32_t usage = 0;
     size_t i = 11;
-    uint32_t total_register = 0x8E0003 | ((tarrif*10) << 8);
+    uint32_t total_register = 0x8E0003 | ((tarrif*16) << 8);
     while (i < telegram.size()) {
       uint32_t c = (((uint32_t)telegram[i+0] << 16) | ((uint32_t)telegram[i+1] << 8 ) | ((uint32_t)telegram[i+2]) );
       if (c == total_register) {

--- a/driver_amiplus.h
+++ b/driver_amiplus.h
@@ -66,7 +66,7 @@ private:
     while (i < telegram.size()) {
       uint32_t c = (((uint32_t)telegram[i+0] << 16) | ((uint32_t)telegram[i+1] << 8 ) | ((uint32_t)telegram[i+2]) );
       if (c == total_register) {
-        i += 4;
+        i += 3;
         usage = bcd_2_int(telegram, i, 6);
         ret_val = usage / 1000.0;
         ESP_LOGVV(TAG, "Found register '%X' with '%d'->'%f'", total_register, usage, ret_val.value());


### PR DESCRIPTION
Added total_energy_production_tX_kwh and total_energy_consumption_tX_kwh for tarrifs T1, T2, T3, T3, according to documentation https://amiplus.tauron-dystrybucja.pl/-/media/offer-documents/amiplus/amiplus-modu-wireless-m-bus.ashx